### PR TITLE
Explicitly order tags by popularity descending

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -132,7 +132,8 @@ class Post extends Eloquent
             'term_relationships',
             'object_id',
             'term_taxonomy_id'
-        )->select(['terms.*', 'term_taxonomy.*']);
+        )->select(['terms.*', 'term_taxonomy.*'])
+        ->orderBy('count', 'desc');
     }
 
     /**


### PR DESCRIPTION
Tags currently are sorted by the order in which they enter the db, regardless of the order they're added to the post. Force a consistent ordering of descending popularity.
